### PR TITLE
Add *LOG to bsion + fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,7 +185,7 @@ func listen(conn net.Conn, session *discordgo.Session, db *sql.DB, pw string) {
 				break
 			}
 
-			if len(tokens) < 4 {
+			if len(tokens) < 3 {
 				log.Println("incoming log was not valid: ", message)
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -176,6 +176,35 @@ func listen(conn net.Conn, session *discordgo.Session, db *sql.DB, pw string) {
 			}
 
 			dbwrite(db, baddie, reportcount)
+		} else if isValidTcprMessage(&message, "*LOG") {
+			regex := regexp.MustCompile("\\*LOG \\*MESSAGE=\\\"(.*?)\\\" \\*SERVERNAME=\\\"(.*?)\\\" \\*SERVERIP=\\\"(.*?)\\\"")
+
+			tokens := regex.FindStringSubmatch(message)
+			if err != nil {
+				log.Println("can't find substring,", err)
+				break
+			}
+
+			if len(tokens) < 4 {
+				log.Println("incoming log was not valid: ", message)
+				continue
+			}
+
+			fmt.Println(tokens[1:])
+
+			message, servername, serverip := tokens[1], tokens[2], tokens[3]
+
+			serverlink := "<kag://" + serverip + "/>"
+
+			fmt.Println("got a log message")
+
+			_, err := session.ChannelMessageSend(configFile.Channel, message+"\n"+
+				"Server: "+servername+"\n"+
+				"Address: "+serverlink)
+			if err != nil {
+				log.Println("cant send message,", err)
+				break
+			}
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -119,6 +119,12 @@ func listen(conn net.Conn, session *discordgo.Session, db *sql.DB, pw string) {
 				log.Println("can't find substring,", err)
 				break
 			}
+
+			if len(tokens) < 6 {
+				log.Println("incoming report was not valid: ", message)
+				continue
+			}
+
 			fmt.Println(tokens[1:])
 
 			//tokens := strings.Split(message, " ")

--- a/main.go
+++ b/main.go
@@ -117,10 +117,6 @@ func listen(conn net.Conn, session *discordgo.Session, db *sql.DB, pw string) {
 		if isValidTcprMessage(&message, "*REPORT") {
 			regex := regexp.MustCompile("\\*REPORT \\*PLAYER=\\\"(.*?)\\\" \\*BADDIE=\\\"(.*?)\\\" \\*COUNT=\\\"(\\d*?)\\\" \\*SERVERNAME=\\\"(.*?)\\\" \\*SERVERIP=\\\"(.*?)\\\" \\*REASON=\\\"(.*?)\\\"")
 			tokens := regex.FindStringSubmatch(message)
-			if err != nil {
-				log.Println("can't find substring,", err)
-				break
-			}
 
 			if len(tokens) < 6 {
 				log.Println("incoming report was not valid: ", message)
@@ -180,10 +176,6 @@ func listen(conn net.Conn, session *discordgo.Session, db *sql.DB, pw string) {
 			regex := regexp.MustCompile("\\*LOG \\*MESSAGE=\\\"(.*?)\\\" \\*SERVERNAME=\\\"(.*?)\\\" \\*SERVERIP=\\\"(.*?)\\\"")
 
 			tokens := regex.FindStringSubmatch(message)
-			if err != nil {
-				log.Println("can't find substring,", err)
-				break
-			}
 
 			if len(tokens) < 3 {
 				log.Println("incoming log was not valid: ", message)


### PR DESCRIPTION
The main idea here is to allow us to send any 'message' to get logged. 

The format is `*LOG *MESSAGE="message_here" *SERVERNAME="some_name" *SERVERIP="some_ip"`. Messages are not sanitized, as this will be handled by KAG script side (but we could also add here if needed).


This also fixes two exploits:
- Users can forge *REPORT messages by typing in chat
- Users can crash bsion by sending an incomplete *REPORT message


